### PR TITLE
Use (file[0] == '.') test instead of a full regexp to ignore hidden files

### DIFF
--- a/lib/stalker.js
+++ b/lib/stalker.js
@@ -20,7 +20,7 @@
         if (err) { return fnAdd && fnAdd(err); }
 
         files.forEach(function _forEach(file){
-          if (/^\./.test(file)) { return; } //ignore files starting with "."
+          if (file[0] == '.') { return; } //ignore files starting with "."
 
           var fPath = path.join(folderPath, file);
           fs.stat(fPath, function _stat(err, stats) {
@@ -75,7 +75,7 @@
           if (err) { return fnAdd && fnAdd(err); }
 
           files.forEach(function (file) {
-            if (/^\./.test(file)) { return; } //ignore files starting with "."
+            if (file[0] == '.') { return; } //ignore files starting with "."
 
             var rPath = path.join(fPath, file);
             watchFolderTree(rPath, fnAdd, fnRemove);


### PR DESCRIPTION
Use a simple (file[0] == '.') test instead of a full regexp to ignore hidden files
